### PR TITLE
Notrailingspaces

### DIFF
--- a/pkg/output/markdown.go
+++ b/pkg/output/markdown.go
@@ -32,13 +32,11 @@ func Markdown(log *logrus.Logger, changeLogFilePath string, releases []*helm.Rel
 
 	for _, release := range releases {
 
-		deprecationNode := ""
-		if release.Chart.Deprecated {
+    if release.Chart.Deprecated {
       f.WriteString(fmt.Sprintf("## %s (DEPRECATED)\n\n", release.Chart.Version))
     } else {
       f.WriteString(fmt.Sprintf("## %s\n\n", release.Chart.Version))
     }
-
 
 		if release.ReleaseDate != nil {
 			f.WriteString(fmt.Sprintf("**Release date:** %s\n\n", release.ReleaseDate.Format("2006-01-02")))

--- a/pkg/output/markdown.go
+++ b/pkg/output/markdown.go
@@ -34,10 +34,11 @@ func Markdown(log *logrus.Logger, changeLogFilePath string, releases []*helm.Rel
 
 		deprecationNode := ""
 		if release.Chart.Deprecated {
-			deprecationNode = "(DEPRECATED)"
-		}
+      f.WriteString(fmt.Sprintf("## %s (DEPRECATED)\n\n", release.Chart.Version))
+    } else {
+      f.WriteString(fmt.Sprintf("## %s\n\n", release.Chart.Version))
+    }
 
-		f.WriteString(fmt.Sprintf("## %s %s\n\n", release.Chart.Version, deprecationNode))
 
 		if release.ReleaseDate != nil {
 			f.WriteString(fmt.Sprintf("**Release date:** %s\n\n", release.ReleaseDate.Format("2006-01-02")))
@@ -67,7 +68,7 @@ func Markdown(log *logrus.Logger, changeLogFilePath string, releases []*helm.Rel
 		f.WriteString("\n\n")
 
 		for _, l := range release.Commits {
-			f.WriteString(fmt.Sprintf("* %s \n", l.Subject))
+			f.WriteString(fmt.Sprintf("* %s\n", l.Subject))
 		}
 
 		f.WriteString("\n")


### PR DESCRIPTION
I removed trailling whitespaces generated at the end of titles and commit messages.
Most linters and editors don't like spaces at the end of the line.