### PR TITLE
feat: make changelog filename configurable

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var changelogFilename string
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "helm-changelog",
@@ -53,7 +55,7 @@ var rootCmd = &cobra.Command{
 
 			releases := helm.CreateHelmReleases(log, chartFile, relativeChartDir, g, allCommits)
 
-			changeLogFilePath := filepath.Join(fullChartDir, "Changelog.md")
+			changeLogFilePath := filepath.Join(fullChartDir, changelogFilename)
 			output.Markdown(log, changeLogFilePath, releases)
 		}
 	},
@@ -71,6 +73,7 @@ func Execute() {
 		return nil
 	}
 
+	rootCmd.PersistentFlags().StringVarP(&changelogFilename, "filename", "f", "Changelog.md", "Filename for changelog")
 	rootCmd.PersistentFlags().StringVarP(&v, "verbosity", "v", logrus.WarnLevel.String(), "Log level (debug, info, warn, error, fatal, panic)")
 
 	cobra.CheckErr(rootCmd.Execute())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,8 +13,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var changelogFilename string
-
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "helm-changelog",
@@ -55,7 +53,7 @@ var rootCmd = &cobra.Command{
 
 			releases := helm.CreateHelmReleases(log, chartFile, relativeChartDir, g, allCommits)
 
-			changeLogFilePath := filepath.Join(fullChartDir, changelogFilename)
+			changeLogFilePath := filepath.Join(fullChartDir, "Changelog.md")
 			output.Markdown(log, changeLogFilePath, releases)
 		}
 	},
@@ -73,8 +71,6 @@ func Execute() {
 		return nil
 	}
 
-
-	rootCmd.PersistentFlags().StringVarP(&changelogFilename, "filename", "f", "CHANGELOG.md", "Filename for changelog")
 	rootCmd.PersistentFlags().StringVarP(&v, "verbosity", "v", logrus.WarnLevel.String(), "Log level (debug, info, warn, error, fatal, panic)")
 
 	cobra.CheckErr(rootCmd.Execute())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var changelogFilename string
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "helm-changelog",
@@ -53,7 +55,7 @@ var rootCmd = &cobra.Command{
 
 			releases := helm.CreateHelmReleases(log, chartFile, relativeChartDir, g, allCommits)
 
-			changeLogFilePath := filepath.Join(fullChartDir, "Changelog.md")
+			changeLogFilePath := filepath.Join(fullChartDir, changelogFilename)
 			output.Markdown(log, changeLogFilePath, releases)
 		}
 	},
@@ -72,6 +74,7 @@ func Execute() {
 	}
 
 	rootCmd.PersistentFlags().StringVarP(&v, "verbosity", "v", logrus.WarnLevel.String(), "Log level (debug, info, warn, error, fatal, panic")
+	rootCmd.PersistentFlags().StringVarP(&changelogFilename, "filename", "f", "CHANGELOG.md", "Filename for changelog")
 
 	cobra.CheckErr(rootCmd.Execute())
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,8 +13,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var changelogFilename string
-
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "helm-changelog",
@@ -55,7 +53,7 @@ var rootCmd = &cobra.Command{
 
 			releases := helm.CreateHelmReleases(log, chartFile, relativeChartDir, g, allCommits)
 
-			changeLogFilePath := filepath.Join(fullChartDir, changelogFilename)
+			changeLogFilePath := filepath.Join(fullChartDir, "Changelog.md")
 			output.Markdown(log, changeLogFilePath, releases)
 		}
 	},
@@ -73,7 +71,6 @@ func Execute() {
 		return nil
 	}
 
-	rootCmd.PersistentFlags().StringVarP(&changelogFilename, "filename", "f", "CHANGELOG.md", "Filename for changelog")
 	rootCmd.PersistentFlags().StringVarP(&v, "verbosity", "v", logrus.WarnLevel.String(), "Log level (debug, info, warn, error, fatal, panic)")
 
 	cobra.CheckErr(rootCmd.Execute())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var changelogFilename string
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "helm-changelog",
@@ -53,7 +55,7 @@ var rootCmd = &cobra.Command{
 
 			releases := helm.CreateHelmReleases(log, chartFile, relativeChartDir, g, allCommits)
 
-			changeLogFilePath := filepath.Join(fullChartDir, "Changelog.md")
+			changeLogFilePath := filepath.Join(fullChartDir, changelogFilename)
 			output.Markdown(log, changeLogFilePath, releases)
 		}
 	},
@@ -71,6 +73,7 @@ func Execute() {
 		return nil
 	}
 
+	rootCmd.PersistentFlags().StringVarP(&changelogFilename, "filename", "f", "CHANGELOG.md", "Filename for changelog")
 	rootCmd.PersistentFlags().StringVarP(&v, "verbosity", "v", logrus.WarnLevel.String(), "Log level (debug, info, warn, error, fatal, panic)")
 
 	cobra.CheckErr(rootCmd.Execute())

--- a/hack/integration-tests.sh
+++ b/hack/integration-tests.sh
@@ -12,7 +12,7 @@ git clone git@github.com:prometheus-community/helm-charts.git charts/prometheus-
 
 rm examples/*.md
 
-for changelog in $(find charts -name 'CHANGELOG.md'); do
+for changelog in $(find charts -name 'Changelog.md'); do
     echo $changelog
     dirName=$(dirname $changelog)
     cp $changelog examples/$(basename ${dirName}).md

--- a/hack/integration-tests.sh
+++ b/hack/integration-tests.sh
@@ -12,7 +12,7 @@ git clone git@github.com:prometheus-community/helm-charts.git charts/prometheus-
 
 rm examples/*.md
 
-for changelog in $(find charts -name 'Changelog.md'); do
+for changelog in $(find charts -name 'CHANGELOG.md'); do
     echo $changelog
     dirName=$(dirname $changelog)
     cp $changelog examples/$(basename ${dirName}).md


### PR DESCRIPTION
Optional parameter `-f` or `--filename` is added to specify the name of the changelog file

