### PR TITLE
QueryEscape markdown badge values for badge creation

### DIFF
--- a/pkg/output/markdown.go
+++ b/pkg/output/markdown.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -32,11 +33,11 @@ func Markdown(log *logrus.Logger, changeLogFilePath string, releases []*helm.Rel
 
 	for _, release := range releases {
 
-    if release.Chart.Deprecated {
-      f.WriteString(fmt.Sprintf("## %s (DEPRECATED)\n\n", release.Chart.Version))
-    } else {
-      f.WriteString(fmt.Sprintf("## %s\n\n", release.Chart.Version))
-    }
+		if release.Chart.Deprecated {
+			f.WriteString(fmt.Sprintf("## %s (DEPRECATED)\n\n", release.Chart.Version))
+		} else {
+			f.WriteString(fmt.Sprintf("## %s\n\n", release.Chart.Version))
+		}
 
 		if release.ReleaseDate != nil {
 			f.WriteString(fmt.Sprintf("**Release date:** %s\n\n", release.ReleaseDate.Format("2006-01-02")))
@@ -88,5 +89,5 @@ func Markdown(log *logrus.Logger, changeLogFilePath string, releases []*helm.Rel
 }
 
 func badge(key, value, icon, style string) string {
-	return fmt.Sprintf("![%s: %s](https://img.shields.io/static/v1?label=%s&message=%s&color=%s&logo=%s)\n", key, value, key, value, style, icon)
+	return fmt.Sprintf("![%s: %s](https://img.shields.io/static/v1?label=%s&message=%s&color=%s&logo=%s)\n", key, value, key, url.QueryEscape(value), style, icon)
 }


### PR DESCRIPTION
This PR includes URL escaping for badge value creation.

It was observed that Kubernetes badges were not properly escaped when containing comparative operators ( >= etc ), resulting in unrendered badges.

This change was validated locally to overcome the badging issue.