### PR TITLE
:art: Improve helm-changelog output

### DIFF
--- a/pkg/output/markdown.go
+++ b/pkg/output/markdown.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 
@@ -36,11 +37,7 @@ func Markdown(log *logrus.Logger, changeLogFilePath string, releases []*helm.Rel
 		if release.Chart.Deprecated {
 			f.WriteString(fmt.Sprintf("## %s (DEPRECATED)\n\n", release.Chart.Version))
 		} else {
-			f.WriteString(fmt.Sprintf("## %s\n\n", release.Chart.Version))
-		}
-
-		if release.ReleaseDate != nil {
-			f.WriteString(fmt.Sprintf("**Release date:** %s\n\n", release.ReleaseDate.Format("2006-01-02")))
+			f.WriteString(fmt.Sprintf("## %s ", strings.TrimSpace(release.Chart.Version)))
 		}
 
 		if release.Chart.AppVersion != "" {
@@ -66,19 +63,21 @@ func Markdown(log *logrus.Logger, changeLogFilePath string, releases []*helm.Rel
 
 		f.WriteString("\n\n")
 
-		for _, l := range release.Commits {
-			f.WriteString(fmt.Sprintf("* %s\n", l.Subject))
+		if release.ReleaseDate != nil {
+			f.WriteString(fmt.Sprintf("**Release date:** %s\n\n", release.ReleaseDate.Format("2006-01-02")))
 		}
 
-		f.WriteString("\n")
-		f.WriteString("### Default value changes\n\n")
-		f.WriteString("```diff\n")
-		if release.ValueDiff == "" {
-			f.WriteString("# No changes in this release\n")
-		} else {
-			f.WriteString(release.ValueDiff)
+		for _, l := range release.Commits {
+			f.WriteString(fmt.Sprintf("* %s\n", strings.TrimSpace(l.Subject)))
 		}
-		f.WriteString("```\n")
+		f.WriteString("\n")
+
+		if release.ValueDiff != "" {
+			f.WriteString("### Default value changes\n\n")
+			f.WriteString("```diff\n")
+			f.WriteString(release.ValueDiff)
+			f.WriteString("```\n")
+		}
 
 		f.WriteString("\n")
 	}
@@ -89,5 +88,5 @@ func Markdown(log *logrus.Logger, changeLogFilePath string, releases []*helm.Rel
 }
 
 func badge(key, value, icon, style string) string {
-	return fmt.Sprintf("![%s: %s](https://img.shields.io/static/v1?label=%s&message=%s&color=%s&logo=%s)\n", key, value, key, url.QueryEscape(value), style, icon)
+	return fmt.Sprintf(" ![%s: %s](https://img.shields.io/static/v1?label=%s&message=%s&color=%s&logo=%s)", key, value, key, url.QueryEscape(value), style, icon)
 }


### PR DESCRIPTION
This PR aims to improve helm-changelog output. 

* Remove trailing whitespace on commit message & release version
* Remove _Default Values changes_ block when there is no change
* Put badges into Chart Version h2 for less lines and more readability
